### PR TITLE
fixing a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gulp plugin version of http://cssstats.com
 
 ```js
 var gulp = require('gulp');
-var basswork = require('gulp-cssstats');
+var cssstats = require('gulp-cssstats');
 
 gulp.task('cssstats', function() {
   gulp.src('./base.css')


### PR DESCRIPTION
there's a typo in the README, you're naming a module something and calling it the task something different
